### PR TITLE
fix: Enable semantic commits on Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,5 +22,6 @@
   ],
   "prHourlyLimit": 5,
   "prConcurrentLimit": 10,
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "semanticCommits": "enabled"
 }


### PR DESCRIPTION
Conflicts with semantic checker is preventing automerge